### PR TITLE
Migrate to GRACC backend (GRACC-18)

### DIFF
--- a/config/osg_display.conf
+++ b/config/osg_display.conf
@@ -60,26 +60,6 @@ Line_transfer_volume_hourly=#3A617B
 Line_transfer_volume_monthly=#3A617B
 Line_transfer_volume_daily=#3A617B
 
-[Gratia]
-host=gr-osg-mysql-reports.opensciencegrid.org
-port=3306
-database=gratia
-user=reader
-password=reader
-hours=24
-days=30
-months=12
-
-[Gratia Transfer]
-host=gr-osg-mysql-reports.opensciencegrid.org
-port=3306
-database=gratia_osg_transfer
-user=reader
-password=reader
-hours=60
-days=30
-months=12
-
 [Gracc]
 url=https://gracc.opensciencegrid.org/q
 hours=24

--- a/config/osg_display.conf
+++ b/config/osg_display.conf
@@ -60,13 +60,13 @@ Line_transfer_volume_hourly=#3A617B
 Line_transfer_volume_monthly=#3A617B
 Line_transfer_volume_daily=#3A617B
 
-[Gracc]
+[GRACC]
 url=https://gracc.opensciencegrid.org/q
 hours=24
 days=30
 months=12
 
-[Gracc Transfer]
+[GRACC Transfer]
 url=https://gracc.opensciencegrid.org/q
 hours=60
 days=30

--- a/config/osg_display.conf
+++ b/config/osg_display.conf
@@ -80,6 +80,18 @@ hours=60
 days=30
 months=12
 
+[Gracc]
+url=https://gracc.opensciencegrid.org/q
+hours=24
+days=30
+months=12
+
+[Gracc Transfer]
+url=https://gracc.opensciencegrid.org/q
+hours=60
+days=30
+months=12
+
 [Filenames]
 graph_output=svg,jpg,png
 directory = /var/www/html/osg_display

--- a/src/osg_display/display_graph.py
+++ b/src/osg_display/display_graph.py
@@ -1,6 +1,9 @@
 
 import os
-import Image
+try:
+    import Image
+except ImportError:
+    from PIL import Image
 import types
 import matplotlib
 matplotlib.use("Agg")

--- a/src/osg_display/gratia_datasource.py
+++ b/src/osg_display/gratia_datasource.py
@@ -192,10 +192,10 @@ class DataSource(object):
 	#remove the cache elements that will be refreshed
 	if(len(cachedresultslist) > 0):
 		cachedresultslist=cachedresultslist[:(len(cachedresultslist)-self.refreshwindowperiod)]	
+		param['starttime'] = start
 	else:
-		start = param['starttime']	
 		log.debug("Setting date back to  start: <%s> "%(param['starttime']))
-	return 	cachedresultslist, {'starttime': start, 'endtime': end}	
+	return cachedresultslist, param
 
 
 class HourlyJobsDataSource(DataSource):

--- a/src/osg_display/gratia_datasource.py
+++ b/src/osg_display/gratia_datasource.py
@@ -83,16 +83,16 @@ class DataSource(object):
                 ca_certs='/etc/ssl/certs/ca-bundle.crt')
         except Exception, e:
             log.exception(e)
-            log.error("Unable to connect to Gracc database")
+            log.error("Unable to connect to GRACC database")
             raise
 
     def connect(self):
-        gracc_url = self.cp.get("Gracc", "Url")
+        gracc_url = self.cp.get("GRACC", "Url")
         #gracc_url = 'https://gracc.opensciencegrid.org/q'
         self.connect_gracc_url(gracc_url)
 
     def connect_transfer(self):
-        gracc_url = self.cp.get("Gracc Transfer", "Url")
+        gracc_url = self.cp.get("GRACC Transfer", "Url")
         #gracc_url = 'https://gracc.opensciencegrid.org/q'
         self.connect_gracc_url(gracc_url)
 
@@ -156,7 +156,7 @@ class HourlyJobsDataSource(DataSource):
         self.hour_results = None
 
     def get_params(self):
-        hours = int(int(self.cp.get("Gracc", "hours"))*1.5)
+        hours = int(int(self.cp.get("GRACC", "hours"))*1.5)
         now = int(time.time()-60)
         prev = now - 3600*hours
         offset = prev % 3600
@@ -191,7 +191,7 @@ class HourlyJobsDataSource(DataSource):
             log.debug("Time %s: Count %i, Hours %.2f" % (time_str, count, hrs))
         count_results = [i[0] for i in all_results]
         hour_results = [i[1] for i in all_results]
-        num_results = int(self.cp.get("Gracc", "hours"))
+        num_results = int(self.cp.get("GRACC", "hours"))
         count_results = count_results[-num_results-1:-1]
         hour_results = hour_results[-num_results-1:-1]
         self.count_results, self.hour_results = count_results, hour_results
@@ -211,7 +211,7 @@ class MonthlyDataSource(DataSource):
         return returnval
 	
     def get_params(self):
-        months = int(int(self.cp.get("Gracc", "months"))+2)
+        months = int(int(self.cp.get("GRACC", "months"))+2)
         end = datetime.datetime(*(list(time.gmtime()[:2]) + [1,0,0,0]))
         start = end - datetime.timedelta(14*31, 0)
         start -= datetime.timedelta(start.day-1, 0)
@@ -250,7 +250,7 @@ class MonthlyDataSource(DataSource):
                 (time_str, count, hrs))
         count_results = [i[0] for i in all_results]
         hour_results = [i[1] for i in all_results]
-        num_results = int(self.cp.get("Gracc", "months"))
+        num_results = int(self.cp.get("GRACC", "months"))
         count_results = count_results[-num_results:]
         hour_results = hour_results[-num_results:]
         self.count_results, self.hour_results = count_results, hour_results
@@ -287,7 +287,7 @@ class MonthlyDataSource(DataSource):
         month_results = [i[0] for i in all_results]
         count_results = [i[1] for i in all_results]
         hour_results = [i[2] for i in all_results]
-        num_results = int(self.cp.get("Gracc", "months"))
+        num_results = int(self.cp.get("GRACC", "months"))
         month_results = month_results[-num_results:]
         count_results = count_results[-num_results:]
         hour_results = hour_results[-num_results:]
@@ -319,7 +319,7 @@ class DailyDataSource(DataSource):
         return returnval
 
     def get_params(self):
-        days = int(int(self.cp.get("Gracc", "days"))+2)
+        days = int(int(self.cp.get("GRACC", "days"))+2)
         end = datetime.datetime(*(list(time.gmtime()[:3]) + [0,0,0]))
         start = end - datetime.timedelta(days, 0)
         start -= datetime.timedelta(start.day-1, 0)
@@ -358,7 +358,7 @@ class DailyDataSource(DataSource):
                 (time_str, count, hrs))
         count_results = [i[0] for i in all_results]
         hour_results = [i[1] for i in all_results]
-        num_results = int(self.cp.get("Gracc", "days"))
+        num_results = int(self.cp.get("GRACC", "days"))
         count_results = count_results[-num_results-1:-1]
         hour_results = hour_results[-num_results-1:-1]
         self.count_results, self.hour_results = count_results, hour_results
@@ -396,7 +396,7 @@ class DailyDataSource(DataSource):
                 (i[0], count, mbs/1024**2))
         count_results = [i[1] for i in all_results]
         hour_results = [i[2] for i in all_results]
-        num_results = int(self.cp.get("Gracc", "days"))
+        num_results = int(self.cp.get("GRACC", "days"))
         count_results = count_results[-num_results-1:-1]
         hour_results = hour_results[-num_results-1:-1]
 

--- a/src/osg_display/gratia_datasource.py
+++ b/src/osg_display/gratia_datasource.py
@@ -209,7 +209,7 @@ class HourlyJobsDataSource(DataSource):
         self.hour_results = None
 
     def get_params(self):
-        hours = int(int(self.cp.get("Gratia", "hours"))*1.5)
+        hours = int(int(self.cp.get("Gracc", "hours"))*1.5)
         now = int(time.time()-60)
         prev = now - 3600*hours
         offset = prev % 3600
@@ -246,7 +246,7 @@ class HourlyJobsDataSource(DataSource):
             log.debug("Time %s: Count %i, Hours %.2f" % (time_str, count, hrs))
         count_results = [i[0] for i in all_results]
         hour_results = [i[1] for i in all_results]
-        num_results = int(self.cp.get("Gratia", "hours"))
+        num_results = int(self.cp.get("Gracc", "hours"))
         count_results = count_results[-num_results-1:-1]
         hour_results = hour_results[-num_results-1:-1]
         self.count_results, self.hour_results = count_results, hour_results
@@ -299,7 +299,7 @@ class MonthlyDataSource(DataSource):
         return returnval
 	
     def get_params(self):
-        months = int(int(self.cp.get("Gratia", "months"))+2)
+        months = int(int(self.cp.get("Gracc", "months"))+2)
         end = datetime.datetime(*(list(time.gmtime()[:2]) + [1,0,0,0]))
         start = end - datetime.timedelta(14*31, 0)
         start -= datetime.timedelta(start.day-1, 0)
@@ -339,7 +339,7 @@ class MonthlyDataSource(DataSource):
                 (time_str, count, hrs))
         count_results = [i[0] for i in all_results]
         hour_results = [i[1] for i in all_results]
-        num_results = int(self.cp.get("Gratia", "months"))
+        num_results = int(self.cp.get("Gracc", "months"))
         count_results = count_results[-num_results:]
         hour_results = hour_results[-num_results:]
         self.count_results, self.hour_results = count_results, hour_results
@@ -377,7 +377,7 @@ class MonthlyDataSource(DataSource):
         month_results = [i[0] for i in all_results]
         count_results = [i[1] for i in all_results]
         hour_results = [i[2] for i in all_results]
-        num_results = int(self.cp.get("Gratia", "months"))
+        num_results = int(self.cp.get("Gracc", "months"))
         month_results = month_results[-num_results:]
         count_results = count_results[-num_results:]
         hour_results = hour_results[-num_results:]
@@ -467,7 +467,7 @@ class DailyDataSource(DataSource):
         return returnval
 
     def get_params(self):
-        days = int(int(self.cp.get("Gratia", "days"))+2)
+        days = int(int(self.cp.get("Gracc", "days"))+2)
         end = datetime.datetime(*(list(time.gmtime()[:3]) + [0,0,0]))
         start = end - datetime.timedelta(days, 0)
         start -= datetime.timedelta(start.day-1, 0)
@@ -507,7 +507,7 @@ class DailyDataSource(DataSource):
                 (time_str, count, hrs))
         count_results = [i[0] for i in all_results]
         hour_results = [i[1] for i in all_results]
-        num_results = int(self.cp.get("Gratia", "days"))
+        num_results = int(self.cp.get("Gracc", "days"))
         count_results = count_results[-num_results-1:-1]
         hour_results = hour_results[-num_results-1:-1]
         self.count_results, self.hour_results = count_results, hour_results
@@ -546,7 +546,7 @@ class DailyDataSource(DataSource):
                 (i[0], count, mbs/1024**2))
         count_results = [i[1] for i in all_results]
         hour_results = [i[2] for i in all_results]
-        num_results = int(self.cp.get("Gratia", "days"))
+        num_results = int(self.cp.get("Gracc", "days"))
         count_results = count_results[-num_results-1:-1]
         hour_results = hour_results[-num_results-1:-1]
 

--- a/src/osg_display/gratia_datasource.py
+++ b/src/osg_display/gratia_datasource.py
@@ -200,7 +200,7 @@ class DataSource(object):
 
 class HourlyJobsDataSource(DataSource):
     """
-    Hourly view of the Gratia job data
+    Hourly view of the GRACC job data
     """
 
     def __init__(self, cp):
@@ -363,7 +363,7 @@ class MonthlyDataSource(DataSource):
 
         cachedresultslist.extend(all_results)
         all_results=cachedresultslist
-        log.info( "-------- Gratia returned %i results for transfers----------------" % len(all_results))
+        log.info( "-------- GRACC returned %i results for transfers----------------" % len(all_results))
         log.debug("-------- Transfer result dump: DB Fetched results----------------" )
         for i in all_results:
             count, mbs = i[1:]
@@ -454,7 +454,7 @@ class MonthlyDataSource(DataSource):
 class DailyDataSource(DataSource):
     """
     Data source to provide transfer and job information over the past 30
-    days.  Queries the Gratia summary tables for jobs and transfers.
+    days.  Queries the GRACC summary index for jobs and transfers.
     """
     refreshwindowperiod=5
     deprecate_cache_after=10  #deprecate cache after these number of reads
@@ -533,7 +533,7 @@ class DailyDataSource(DataSource):
         cachedresultslist.extend(all_results)
         all_results=cachedresultslist
 
-        log.info( "-------- Gratia returned %i results for transfers----------------" % len(all_results))
+        log.info( "-------- GRACC returned %i results for transfers----------------" % len(all_results))
         log.debug("-------- Transfer result dump: DB Fetched results----------------" )
         for i in all_results:
             count, mbs = i[1:]

--- a/src/osg_display/gratia_datasource.py
+++ b/src/osg_display/gratia_datasource.py
@@ -238,14 +238,14 @@ class MonthlyDataSource(DataSource):
     def query_transfers(self):
         self.connect_transfer()
         curs = self.conn.cursor()
-	cachedresultslist, params=self.getcache()
-	log.debug("Received  <%s> cached results"%(len(cachedresultslist)))
-	log.debug("Received in query_transfers for DB Query start date: <%s> and end date <%s> "%(params['starttime'],params['endtime']))
+        cachedresultslist, params=self.getcache()
+        log.debug("Received  <%s> cached results"%(len(cachedresultslist)))
+        log.debug("Received in query_transfers for DB Query start date: <%s> and end date <%s> "%(params['starttime'],params['endtime']))
         curs.execute(self.transfers_query, params)
         results = curs.fetchall()
         all_results = [(i[0],i[1], i[2]) for i in results]
-	cachedresultslist.extend(all_results)
-	all_results=cachedresultslist
+        cachedresultslist.extend(all_results)
+        all_results=cachedresultslist
         log.info( "-------- Gratia returned %i results for transfers----------------" % len(all_results))
         log.debug("-------- Transfer result dump: DB Fetched results----------------" )
         for i in results:
@@ -265,10 +265,10 @@ class MonthlyDataSource(DataSource):
         count_results = count_results[-num_results:]
         hour_results = hour_results[-num_results:]
 
-	#write the data to cache file
-	pickle_f_handle = open(self.cache_data_file_name, "w")
-	cPickle.dump(all_results, pickle_f_handle)
-	pickle_f_handle.close()
+        #write the data to cache file
+        pickle_f_handle = open(self.cache_data_file_name, "w")
+        cPickle.dump(all_results, pickle_f_handle)
+        pickle_f_handle.close()
 
         self.disconnect()
         self.transfer_results = count_results
@@ -392,15 +392,15 @@ class DailyDataSource(DataSource):
     def query_transfers(self):
         self.connect_transfer()
         curs = self.conn.cursor()
-	cachedresultslist, params=self.getcache()
+        cachedresultslist, params=self.getcache()
 
-	log.debug("Received  <%s> cached results"%(len(cachedresultslist)))
-	log.debug("Received in query_transfers for DB Query start date: <%s> and end date <%s> "%(params['starttime'],params['endtime']))
+        log.debug("Received  <%s> cached results"%(len(cachedresultslist)))
+        log.debug("Received in query_transfers for DB Query start date: <%s> and end date <%s> "%(params['starttime'],params['endtime']))
         curs.execute(self.transfers_query, params)
         results = curs.fetchall()
         all_results = [(i[0],i[1], i[2]) for i in results]
-	cachedresultslist.extend(all_results)
-	all_results=cachedresultslist
+        cachedresultslist.extend(all_results)
+        all_results=cachedresultslist
 
         log.info( "-------- Gratia returned %i results for transfers----------------" % len(all_results))
         log.debug("-------- Transfer result dump: DB Fetched results----------------" )
@@ -419,10 +419,10 @@ class DailyDataSource(DataSource):
         count_results = count_results[-num_results-1:-1]
         hour_results = hour_results[-num_results-1:-1]
 
-	#write the data to cache file
-	pickle_f_handle = open(self.cache_data_file_name, "w")
-	cPickle.dump(all_results, pickle_f_handle)
-	pickle_f_handle.close()
+        #write the data to cache file
+        pickle_f_handle = open(self.cache_data_file_name, "w")
+        cPickle.dump(all_results, pickle_f_handle)
+        pickle_f_handle.close()
 
         self.disconnect()
         self.transfer_results, self.transfer_volume_results = count_results, \

--- a/src/osg_display/gratia_datasource.py
+++ b/src/osg_display/gratia_datasource.py
@@ -2,7 +2,6 @@
 import time
 import os.path
 import cPickle
-import MySQLdb
 import datetime
 import tempfile
 from common import log
@@ -75,25 +74,9 @@ class DataSource(object):
         self.connect()
 
     def disconnect(self):
-        self.conn.close()
+        pass
 
     def connect(self):
-        user = self.cp.get("Gratia", "User")
-        password = self.cp.get("Gratia", "Password")
-        host = self.cp.get("Gratia", "Host")
-        database = self.cp.get("Gratia", "Database")
-        port = int(self.cp.get("Gratia", "Port"))
-        try:
-            self.conn = MySQLdb.connect(user=user, passwd=password, host=host,
-                port=port, db=database)
-            log.info("Successfully connected to Gratia database")
-        except Exception, e:
-            log.exception(e)
-            log.error("Unable to connect to Gratia database")
-            raise
-        curs = self.conn.cursor()
-        curs.execute("set time_zone='+0:00'")
-
         gracc_url = self.cp.get("Gracc", "Url")
         #gracc_url = 'https://gracc.opensciencegrid.org/q'
         try:
@@ -106,21 +89,6 @@ class DataSource(object):
             raise
 
     def connect_transfer(self):
-        user = self.cp.get("Gratia Transfer", "User")
-        password = self.cp.get("Gratia Transfer", "Password")
-        host = self.cp.get("Gratia Transfer", "Host")
-        database = self.cp.get("Gratia Transfer", "Database")
-        port = int(self.cp.get("Gratia Transfer", "Port"))
-        try:
-            self.conn = MySQLdb.connect(user=user, passwd=password, host=host,
-                port=port, db=database)
-        except Exception, e:
-            log.exception(e)
-            log.error("Unable to connect to Gratia Transfer DB")
-            raise
-        curs=self.conn.cursor()
-        curs.execute("set time_zone='+0:00'")
-
         gracc_url = self.cp.get("Gracc Transfer", "Url")
         #gracc_url = 'https://gracc.opensciencegrid.org/q'
         try:

--- a/src/osg_display/gratia_datasource.py
+++ b/src/osg_display/gratia_datasource.py
@@ -76,9 +76,7 @@ class DataSource(object):
     def disconnect(self):
         pass
 
-    def connect(self):
-        gracc_url = self.cp.get("Gracc", "Url")
-        #gracc_url = 'https://gracc.opensciencegrid.org/q'
+    def connect_gracc_url(self, gracc_url):
         try:
             self.es = elasticsearch.Elasticsearch(
                 [gracc_url], timeout=300, use_ssl=True, verify_certs=True,
@@ -88,17 +86,15 @@ class DataSource(object):
             log.error("Unable to connect to Gracc database")
             raise
 
+    def connect(self):
+        gracc_url = self.cp.get("Gracc", "Url")
+        #gracc_url = 'https://gracc.opensciencegrid.org/q'
+        self.connect_gracc_url(gracc_url)
+
     def connect_transfer(self):
         gracc_url = self.cp.get("Gracc Transfer", "Url")
         #gracc_url = 'https://gracc.opensciencegrid.org/q'
-        try:
-            self.es = elasticsearch.Elasticsearch(
-                [gracc_url], timeout=300, use_ssl=True, verify_certs=True,
-                ca_certs='/etc/ssl/certs/ca-bundle.crt')
-        except Exception, e:
-            log.exception(e)
-            log.error("Unable to connect to Gracc database")
-            raise
+        self.connect_gracc_url(gracc_url)
 
     def getcache(self):
 	cachedresultslist=[]

--- a/src/osg_display/transfer_datasource.py
+++ b/src/osg_display/transfer_datasource.py
@@ -222,7 +222,7 @@ class DataSourceTransfers(object):
         all_times = all_times[-26:-1]
         results = []
         for time in all_times:
-            results.append((self.data[time].count, self.data[time].volume_mb))
+            results.append((int(self.data[time].count), self.data[time].volume_mb))
         self.transfer_results, self.transfer_volume_results = zip(*results)
         return results
 

--- a/src/osg_display/transfer_datasource.py
+++ b/src/osg_display/transfer_datasource.py
@@ -70,7 +70,7 @@ class DataSourceTransfers(object):
         pass
  
     def connect(self):
-        gracc_url = self.cp.get("Gracc Transfer", "Url")
+        gracc_url = self.cp.get("GRACC Transfer", "Url")
         #gracc_url = 'https://gracc.opensciencegrid.org/q'
 
         try:
@@ -79,7 +79,7 @@ class DataSourceTransfers(object):
                 ca_certs='/etc/ssl/certs/ca-bundle.crt')
         except Exception, e:
             log.exception(e)
-            log.error("Unable to connect to Gracc database")
+            log.error("Unable to connect to GRACC database")
             raise
 
     def load_cached(self):
@@ -155,7 +155,7 @@ class DataSourceTransfers(object):
         self.missing.add(self._timestamp_to_datetime(hour_now-2*3600))
         self.missing.add(self._timestamp_to_datetime(hour_now-3*3600))
         cur = hour_now
-        hours = int(self.cp.get("Gracc Transfer", "hours"))
+        hours = int(self.cp.get("GRACC Transfer", "hours"))
         while cur >= now - hours*3600:
             cur -= 3600
             cur_dt = self._timestamp_to_datetime(cur)

--- a/src/osg_display/transfer_datasource.py
+++ b/src/osg_display/transfer_datasource.py
@@ -250,20 +250,3 @@ class DataSourceTransfers(object):
             results.append(td.count/float(interval_s))
         return results
 
-
-    transfers_query = """
-        SELECT
-          (truncate((unix_timestamp(ServerDate))/%(span)s, 0)*%(span)s) as time,
-          sum(JR.Njobs) as Records,
-          sum(Value*SU.Multiplier) as SizeMB
-        FROM JobUsageRecord_Meta JURM
-        JOIN Network N on (JURM.dbid = N.dbid)
-        JOIN SizeUnits SU on N.StorageUnit = SU.Unit
-	JOIN JobUsageRecord JR ON JURM.dbid = JR.dbid
-        WHERE
-          ServerDate >= %(starttime)s AND
-          ServerDate < %(endtime)s
-        GROUP BY time;
-        """
-
-

--- a/src/osg_display/transfer_datasource.py
+++ b/src/osg_display/transfer_datasource.py
@@ -1,10 +1,39 @@
 
 import time
 import pickle
-import MySQLdb
 import datetime
 
 from common import log, get_files, commit_files, euid
+
+import elasticsearch
+from elasticsearch_dsl import Search, A, Q
+import logging
+
+
+logging.basicConfig(level=logging.WARN)
+
+transfers_raw_index = 'gracc.osg-transfer.raw-*'
+transfers_summary_index = 'gracc.osg-transfer.summary'
+
+def gracc_query_transfers(es, index, starttime, endtime, interval):
+    s = Search(using=es, index=index)
+
+    s = s.query('bool',
+            filter=[
+             Q('range', StartTime={'gte': starttime, 'lt': endtime })
+          & ~Q('terms', SiteName=['NONE', 'Generic', 'Obsolete'])
+        ]
+    )
+
+    curBucket = s.aggs.bucket('StartTime', 'date_histogram',
+                              field='StartTime', interval=interval)
+
+    curBucket = curBucket.metric('Network', 'sum', field='Network')
+    curBucket = curBucket.metric('Records', 'sum', field='Njobs')
+
+    response = s.execute()
+    return response
+
 
 class TransferData(object):
     """
@@ -23,7 +52,7 @@ class TransferData(object):
 class DataSourceTransfers(object):
     """
     A data source which queries (and caches!) hourly transfer information from
-    Gratia
+    GRACC
     """
 
     def __init__(self, cp):
@@ -38,23 +67,20 @@ class DataSourceTransfers(object):
         self.query_missing()
        
     def disconnect(self):
-        self.conn.close()
+        pass
  
     def connect(self):
-        user = self.cp.get("Gratia Transfer", "User")
-        password = self.cp.get("Gratia Transfer", "Password")
-        host = self.cp.get("Gratia Transfer", "Host")
-        database = self.cp.get("Gratia Transfer", "Database")
-        port = int(self.cp.get("Gratia Transfer", "Port"))
+        gracc_url = self.cp.get("Gracc Transfer", "Url")
+        #gracc_url = 'https://gracc.opensciencegrid.org/q'
+
         try:
-            self.conn = MySQLdb.connect(user=user, passwd=password, host=host,
-                port=port, db=database)
+            self.es = elasticsearch.Elasticsearch(
+                [gracc_url], timeout=300, use_ssl=True, verify_certs=True,
+                ca_certs='/etc/ssl/certs/ca-bundle.crt')
         except Exception, e:
             log.exception(e)
-            log.error("Unable to connect to Gratia Transfer DB")
+            log.error("Unable to connect to Gracc database")
             raise
-        curs=self.conn.cursor()
-        curs.execute("set time_zone='+0:00'")
 
     def load_cached(self):
         try:
@@ -129,7 +155,7 @@ class DataSourceTransfers(object):
         self.missing.add(self._timestamp_to_datetime(hour_now-2*3600))
         self.missing.add(self._timestamp_to_datetime(hour_now-3*3600))
         cur = hour_now
-        hours = int(self.cp.get("Gratia Transfer", "hours"))
+        hours = int(self.cp.get("Gracc Transfer", "hours"))
         while cur >= now - hours*3600:
             cur -= 3600
             cur_dt = self._timestamp_to_datetime(cur)
@@ -165,15 +191,22 @@ class DataSourceTransfers(object):
                 self.save_cache()
 
     def query_transfers(self, starttime, endtime):
-        log.info("Querying Gratia Transfer DB for transfers from %s to %s." \
+        log.info("Querying GRACC Transfer index for transfers from %s to %s." \
             % (starttime.strftime("%Y-%m-%d %H:%M:%S"),
             endtime.strftime("%Y-%m-%d %H:%M:%S")))
-        curs = self.conn.cursor()
-        params = {'span': 3600}
+        params = {'interval': 'hour'}
         params['starttime'] = starttime
         params['endtime'] = endtime
-        curs.execute(self.transfers_query, params)
-        return curs.fetchall()
+
+        response = gracc_query_transfers(self.es, transfers_raw_index, **params)
+
+        results = response.aggregations.StartTime.buckets
+
+        all_results = [ (x.key / 1000,
+                         x.Records.value,
+                         x.Network.value / 1024**2) for x in results ]
+
+        return all_results
 
     def get_json(self):
         assert self.transfer_results != None


### PR DESCRIPTION
Note that this uses the `python-elasticsearch` and `python-elasticsearch-dsl` libraries, which are only usable on EL7.

The new code has been tested and the generated images are within expectations for matching the originals generated using the gratia db.