### PR TITLE
handle empty data sets in zip() (SOFTWARE-3117)

### DIFF
--- a/src/osg_display/transfer_datasource.py
+++ b/src/osg_display/transfer_datasource.py
@@ -227,7 +227,10 @@ class DataSourceTransfers(object):
         results = []
         for time in all_times:
             results.append((int(self.data[time].count), self.data[time].volume_mb))
-        self.transfer_results, self.transfer_volume_results = zip(*results)
+        if results:
+            self.transfer_results, self.transfer_volume_results = zip(*results)
+        else:
+            self.transfer_results, self.transfer_volume_results = [[],[]]
         return results
 
     def get_volume_rates(self):


### PR DESCRIPTION
I missed this more interesting gotcha when results is empty ... `zip()` returns the wrong number of arguments for setting the transfer results members.