### PR TITLE
Change myosg to my.osg.org

### DIFF
--- a/src/osg_display/oim_datasource.py
+++ b/src/osg_display/oim_datasource.py
@@ -16,7 +16,7 @@ class OIMDataSource(object):
     def __init__(self, cp):
         self.cp = cp
 
-    resource_group_url = 'http://myosg.opensciencegrid.org/rgsummary/xml?datasource=' \
+    resource_group_url = 'http://my.opensciencegrid.org/rgsummary/xml?datasource=' \
         'summary&all_resources=on&gridtype=on&gridtype_1=on&active=on&' \
         'active_value=1&disable=on&disable_value=0&' \
         'summary_attrs_showhierarchy=on&summary_attrs_showservice=on' \


### PR DESCRIPTION
myosg.grid.iu.edu exists.  myosg.opensciencegrid.org does not.  Further, the host
behind myosg.grid.iu.edu has a web certificate that does not include myosg.opensciencegrid.org.

So just change it to my.osg.org, which works.